### PR TITLE
Add instruction to setup lsst_distrib

### DIFF
--- a/examples/welcome_to_FE55.ipynb
+++ b/examples/welcome_to_FE55.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "Step-by-step instructions:\n",
     "\n",
-    "1. Start a terminal in JupyterLab. In the terminal, setup the stack: `source /opt/lsst/software/stack/loadLSST.bash`\n",
+    "1. Start a terminal in JupyterLab. In the terminal, setup the Stack with the command `source /opt/lsst/software/stack/loadLSST.bash` and then issue the command `setup lsst_distrib` to allow you to run scons in a subsequent step.\n",
     "\n",
     "2. Create and/or switch into a folder where you want to put your local versions of the LSST Stack (e.g., `~/repos`)\n",
     "\n",


### PR DESCRIPTION
This is a small correction to the setup notes for the `obs_lsst` package. The command `setup lsst_distrib` is needed to use scons later on.